### PR TITLE
remove block preventing this gem from being released

### DIFF
--- a/rails_edge_test.gemspec
+++ b/rails_edge_test.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/NoRedInk/rails_edge_test"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
@jleven can we merge & release the gem? 

before it's released as a gem, we have to pull the gem from github.
- the perf of `bundle install` from git is slower than from rubygems.org
- github goes down far more often than rubygems.org

cons?
- violates semver to release before 1.0