### PR TITLE
Allow to define let blocks at a controller level

### DIFF
--- a/lib/rails_edge_test/dsl.rb
+++ b/lib/rails_edge_test/dsl.rb
@@ -27,6 +27,7 @@ module RailsEdgeTest
                 printer.begin_edge(edge)
 
                 RailsEdgeTest.configuration.wrap_edge_execution do
+                  define_lets(edge, controller.__let_handler)
                   define_lets(edge, action.__let_handler)
                   edge.instance_exec(&block)
                 end

--- a/lib/rails_edge_test/dsl/controller.rb
+++ b/lib/rails_edge_test/dsl/controller.rb
@@ -3,6 +3,7 @@ module RailsEdgeTest::Dsl
     def initialize(*args)
       super
       @actions = []
+      @let_handler = LetHandler.new
     end
 
     def action(name, &block)
@@ -11,8 +12,16 @@ module RailsEdgeTest::Dsl
       @actions << new_action
     end
 
+    def let(title, &block)
+      @let_handler.add_definition(title, &block)
+    end
+
     def __actions
       @actions
+    end
+
+    def __let_handler
+      @let_handler
     end
   end
 end

--- a/spec/rails_edge_test/dsl/let_handler_spec.rb
+++ b/spec/rails_edge_test/dsl/let_handler_spec.rb
@@ -115,6 +115,100 @@ RSpec.describe RailsEdgeTest::Dsl::LetHandler do
     end
   end
 
+  describe "a let block defined within a controller block" do
+    it "is callable within an edge block inside that controller block" do
+      test_value = nil
+
+      Module.new do
+        extend RailsEdgeTest::Dsl
+
+        controller LetHandlerController do
+          let(:christina) { 'genie in a bottle' }
+          action :simple do
+            edge "call let" do
+              test_value = christina
+            end
+          end
+        end
+      end
+
+      RailsEdgeTest::Dsl.execute!
+
+      expect(test_value).to eq 'genie in a bottle'
+    end
+
+    it "allows to be called from multiple actions"  do
+      first_result = second_result = nil
+
+      Module.new do
+        extend RailsEdgeTest::Dsl
+
+        controller LetHandlerController do
+          let(:christina) { 'genie in a bottle' }
+          action :first do
+            edge "call let" do
+              first_result = christina
+            end
+          end
+          action :second do
+            edge "call let" do
+              second_result = christina
+            end
+          end
+        end
+      end
+
+      RailsEdgeTest::Dsl.execute!
+
+      expect(first_result).to eq 'genie in a bottle'
+      expect(second_result).to eq 'genie in a bottle'
+    end
+
+    it "allows to be overridden by a let defined in the action" do
+      test_value = nil
+
+      Module.new do
+        extend RailsEdgeTest::Dsl
+
+        controller LetHandlerController do
+          let(:christina) { 'genie in a bottle' }
+          action :first do
+            let(:christina) { 'genie in a lamp' }
+            edge "call let" do
+              test_value = christina
+            end
+          end
+        end
+      end
+
+      RailsEdgeTest::Dsl.execute!
+
+      expect(test_value).to eq 'genie in a lamp'
+    end
+
+    it "allows let blocks inside an action to reference let blocks inside a controller" do
+      test_value = nil
+
+      Module.new do
+        extend RailsEdgeTest::Dsl
+
+        controller LetHandlerController do
+          let(:christina) { 'genie in a bottle' }
+          action :first do
+            let(:christie) { christina + ' and a lamp' }
+            edge "call let" do
+              test_value = christie
+            end
+          end
+        end
+      end
+
+      RailsEdgeTest::Dsl.execute!
+
+      expect(test_value).to eq 'genie in a bottle and a lamp'
+    end
+  end
+
   describe "a generate block" do
     it "is the same as a let block, but prefixed by 'generate_' when called" do
       test_value = nil


### PR DESCRIPTION
Hello there! This PR adds the ability of defining let blocks inside the `controller` blocks that are available in the enclosed edges. 🍐 with @mavnn