### PR TITLE
Format produced JSON

### DIFF
--- a/lib/rails_edge_test/dsl/edge.rb
+++ b/lib/rails_edge_test/dsl/edge.rb
@@ -73,9 +73,8 @@ module RailsEdgeTest::Dsl
 
       ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
       if ivar
-        controller.
-          send(:instance_variable_get, ivar).
-          to_json
+        value = controller.send(:instance_variable_get, ivar)
+        JSON.pretty_unparse(value)
       else
         response[2].body
       end

--- a/spec/rails_edge_test/dsl/edge_spec.rb
+++ b/spec/rails_edge_test/dsl/edge_spec.rb
@@ -159,7 +159,9 @@ RSpec.describe RailsEdgeTest::Dsl::Edge do
         json : String
         json =
             """
-        {"to":"be embedded"}
+        {
+          "to": "be embedded"
+        }
             """
       ELM
     end


### PR DESCRIPTION
Fixes #6.

This formats the produced JSON so that when generated edge fixtures change, it will be easy to see what has changed in the JSON with version control diffs.