### PR TITLE
Load from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ Edge specifications, like the above, should be put in subfolders of `/edge` and 
 
 ## Generating files
 
-When you want to generate your edge json files, run this:
+When you want to generate all your edge json files, run this:
 
 `bundle exec generate_edges`
 
-You can also pass in a file path relative to the edge root path (usually spec/edge):
+When you can also specify a specific file:
+
+`bundle exec generate_edges spec/edge/rails_controller_edge.rb`
+
+You can also pass in a file path relative to the edge root path (usually `spec/edge`):
+
 `bundle exec generate_edges rails_controller_edge.rb`
 
 ## Some helpful setup

--- a/lib/rails_edge_test/runner.rb
+++ b/lib/rails_edge_test/runner.rb
@@ -15,12 +15,17 @@ module RailsEdgeTest
         glob_path = args.shift
       end
 
-      glob = File.join(
+      glob_with_root_path = File.join(
         RailsEdgeTest.configuration.edge_root_path,
         glob_path
       )
 
-      Dir.glob(glob).each do |file|
+      # load files both at the root path and edge_root_path
+      Dir.glob(glob_path).each do |file|
+        load file
+      end
+
+      Dir.glob(glob_with_root_path).each do |file|
         load file
       end
 

--- a/spec/rails_edge_test/runner_spec.rb
+++ b/spec/rails_edge_test/runner_spec.rb
@@ -47,7 +47,33 @@ RSpec.describe RailsEdgeTest::Runner do
     expect(File.exists? expected_home_filepath).to be false
     expect(File.exists? expected_other_filepath).to be false
 
+    # Provide filepath relative to edge_root_path
     RailsEdgeTest::Runner.go!(["another_edge.rb"])
+
+    expect(File.exists? expected_home_filepath).to be false
+    expect(File.exists? expected_other_filepath).to be true
+
+    elm = File.open(expected_other_filepath, 'r').read(nil)
+    expect(elm).to eq(<<~ELM)
+      module Edge.ApplicationController.Another exposing (json)
+
+
+      json : String
+      json =
+          """
+      {
+        "example": "data"
+      }
+          """
+    ELM
+  end
+
+  it "allows full paths for creating files" do
+    expect(File.exists? expected_home_filepath).to be false
+    expect(File.exists? expected_other_filepath).to be false
+
+    # Provide full filepath relative to root
+    RailsEdgeTest::Runner.go!(["spec/support/test_app/edge/another_edge.rb"])
 
     expect(File.exists? expected_home_filepath).to be false
     expect(File.exists? expected_other_filepath).to be true


### PR DESCRIPTION
Addresses https://github.com/NoRedInk/rails_edge_test/issues/7

I can now run `bundle exec generate_edges edge/spec/my_controller_edge.rb` instead of `bundle exec generate_edges my_controller_edge.rb`, which is more convenient because I can use my terminal's autocomplete.

I'm wondering if it makes sense to require a `--from-root` flag to enable this behavior? I'm leaning towards no, since it'll still filter by `**/*_edge.rb`. Alternatively, maybe it only searches by root if you do pass in an argument, or else it'll search by the default edge root path.