### PR TITLE
Add idempotence rules to the DSL

### DIFF
--- a/lib/rails_edge_test/dsl/edge.rb
+++ b/lib/rails_edge_test/dsl/edge.rb
@@ -24,6 +24,10 @@ module RailsEdgeTest::Dsl
       @response
     end
 
+    def idems
+      @idems ||= []
+    end
+
     def perform_get(parameters = {})
       request.assign_parameters(
         ::Rails.application.routes,
@@ -39,6 +43,28 @@ module RailsEdgeTest::Dsl
       end
 
       @response = controller.dispatch(action, request, response)
+    end
+
+    def add_idempotence_rule(&rule)
+      idems << rule
+    end
+
+    def pin_value(path, value)
+      # Takes "(["key1", "key2"], pinnedValue)" and runs
+      # > json_data["key1"]["key2"] = pinnedValue
+      # It will error if the specified path doesn't already
+      # exist
+      # see https://stackoverflow.com/questions/14294751/how-to-set-nested-hash-in-ruby-dynamically for how this works
+      add_idempotence_rule do |json_data|
+        *keys, last = path
+        parent = keys.inject(json_data, :fetch)
+        if parent.has_key? last
+          parent[last] = value
+        else
+          raise KeyError, "key not found: \"#{last}\""
+        end
+        json_data
+      end
     end
 
     def produce_elm_file(module_name, ivar: nil)
@@ -81,13 +107,18 @@ module RailsEdgeTest::Dsl
       ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
       if ivar
         value = controller.send(:instance_variable_get, ivar)
-        JSON.pretty_unparse(value.as_json)
+        sanitize_json(value.as_json)
       elsif response[1]['Content-Type']&.starts_with?('application/json')
         value = JSON.parse(response[2].body)
-        JSON.pretty_unparse(value)
+        sanitize_json(value)
       else
         response[2].body
       end
+    end
+
+    def sanitize_json(json_data)
+      sanitized = idems.reduce(json_data) { |jd, idem| idem.call jd }
+      JSON.pretty_unparse(sanitized)
     end
 
     def write_file(filepath, filename, data)


### PR DESCRIPTION
Experimental idea: this PR adds "idempotence rules" to edge tests, allowing you to override values that might change from run to run of the edge tests.

`pin_value` pins a value of a specific field in the JSON:

``` ruby
controller ApplicationController do
  action :home do
    edge "write elm file" do
      perform_get
      pin_value(["key1", "key2"], 10)
      produce_elm_file('Home')
    end
  end
end
```

will error if the JSON created doesn't contain an item at `json_data["key1"]["key2"]`. If it does contain an item, it will override it with the pinned value supplied (10).

The more general `add_idempotence_rule` just allows you to supply a block which can carry out arbitrary transformations on the generated JSON hash:

``` ruby
controller ApplicationController do
  action :home do
    edge "write elm file" do
      perform_get
      add_idempotence_rule do |json_data|
        json_data["key1"]["key2"] = 10
      end
      produce_elm_file('Home')
    end
  end
end
```