### PR TITLE
Sort Dir.glob entries

### DIFF
--- a/lib/rails_edge_test/runner.rb
+++ b/lib/rails_edge_test/runner.rb
@@ -19,7 +19,7 @@ module RailsEdgeTest
           )
         end
 
-      Dir.glob(paths_to_load).each do |file|
+      Dir.glob(paths_to_load).sort.each do |file|
         load file
       end
 


### PR DESCRIPTION
This makes the edge spec generation deterministic. Otherwise the order in which `Dir.glob` entries are returned depends on OS and other factors and it sometimes leads to IDs clashing between each other.