### PR TITLE
Helpers can access modules

### DIFF
--- a/lib/rails_edge_test/configuration.rb
+++ b/lib/rails_edge_test/configuration.rb
@@ -15,7 +15,8 @@ module RailsEdgeTest
     # access from within an `edge` block.
     # @param [Module] mod - a module to be included into all `edge` blocks
     def include(mod)
-      Dsl::Edge.include mod
+      Dsl::Controller.include(mod)
+      Dsl::Edge.include(mod)
     end
 
     # Provide a block to be executed once before running any `edge` blocks

--- a/spec/rails_edge_test/configuration_spec.rb
+++ b/spec/rails_edge_test/configuration_spec.rb
@@ -24,7 +24,46 @@ RSpec.describe RailsEdgeTest::Configuration do
 
 
   describe "#include(mod)" do
-    it "includes the mod in each edge" do
+    it "makes module callable from helper functions" do
+      meant_to = nil
+
+      nicki = Module.new do
+        define_method :starships do
+          meant_to = 'fly!'
+        end
+      end
+
+      Module.new do
+        extend RailsEdgeTest::Dsl
+
+        controller Namespace::ConfigurationController do
+          def controller_starships
+            starships
+          end
+
+          action :simple do
+            def action_starships
+              starships
+            end
+
+            edge "blast off" do
+              controller_starships
+              action_starships
+            end
+          end
+        end
+      end
+
+      RailsEdgeTest.configure do |config|
+        config.include(nicki)
+      end
+
+      RailsEdgeTest::Dsl.execute!
+
+      expect(meant_to).to eq 'fly!'
+    end
+
+    it "includes the module in each edge" do
       meant_to = nil
 
       nicki = Module.new do


### PR DESCRIPTION
followup to 1.2.0

@Arkham your monkey patch doesn't seem to fix this case and I'm not sure why...